### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 N-blog
 ======
+[![Known Vulnerabilities](https://snyk.io/test/github/nswbmw/N-blog/badge.svg)](https://snyk.io/test/github/nswbmw/N-blog)
 
 使用 Express + MongoDB 搭建多人博客  
 

--- a/package.json
+++ b/package.json
@@ -4,20 +4,24 @@
   "private": true,
   "description": "N-blog for express4.x",
   "scripts": {
-    "start": "node app"
+    "start": "node app",
+    "test": "snyk test"
   },
   "dependencies": {
-    "express": "4.10.2",
+    "express": "^4.12.4",
     "body-parser": "1.9.0",
     "cookie-parser": "1.3.3",
     "morgan": "1.3.1",
-    "serve-favicon": "2.1.5",
+    "serve-favicon": "^2.2.1",
     "ejs": "1.0.0",
     "markdown": "0.5.0",
     "mongodb": "1.4.15",
-    "express-session": "1.9.1",
+    "express-session": "^1.11.2",
     "connect-flash": "0.1.1",
     "connect-mongo": "0.4.1",
     "multer": "0.1.6"
+  },
+  "devDependencies": {
+    "snyk": "^1.13.3"
   }
 }


### PR DESCRIPTION
`N-blog` currently uses vulnerable version of several dependencies.
You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/nswbmw/N-blog/94ac79f69458edae8a7e970aa460c9af08387dcc

This PR upgrades the vulnerable dependencies to the minimal version that isn't vulnerable. 
This includes no major upgrades, so should have no disruption.

I also added `snyk test` to the test process, to help the project stay vulnerability free (will fail the test if new vulns are introduced). I recommend you also monitor the project by running [`snyk wizard`](https://snyk.io/docs/using-snyk/#wizard), doing so will alert you when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
