### PR TITLE
fix tags & package.json

### DIFF
--- a/models/post.js
+++ b/models/post.js
@@ -328,7 +328,7 @@ Post.getTags = function(callback) {
         if (err) {
           return callback(err);
         }
-        callback(null, docs);
+        callback(null, docs.filter(function(x){ return x.length;}));
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "N-blog",
-  "version": "1.0.0",
+  "name": "blog",
+  "version": "0.0.0",
   "private": true,
-  "description": "N-blog for express4.x",
   "scripts": {
-    "start": "node app"
+    "start": "node app.js"
   },
   "dependencies": {
-    "express": "4.10.2",
-    "body-parser": "1.9.0",
-    "cookie-parser": "1.3.3",
-    "morgan": "1.3.1",
-    "serve-favicon": "2.1.5",
-    "ejs": "1.0.0",
-    "markdown": "0.5.0",
-    "mongodb": "1.4.15",
+    "body-parser": "~1.13.2",
+    "cookie-parser": "~1.3.5",
+    "debug": "~2.2.0",
+    "ejs": "~2.3.3",
+    "express": "~4.13.1",
+    "morgan": "~1.6.1",
+    "serve-favicon": "~2.3.0",
+    "mongodb": "2.1.8",
     "express-session": "1.9.1",
+    "connect-mongo": "0.8.2",
     "connect-flash": "0.1.1",
-    "connect-mongo": "0.4.1",
+    "markdown": "0.5.0",
     "multer": "0.1.6"
   }
 }


### PR DESCRIPTION
原本的package.json现在已经不能运行了，这是我尝试可以运行的版本

另外，关于tags，由于用户填写的tags可能为空(例如某篇文章tags为{'a','','b'})，如果数据库distinct选择出来的tags中间某一个是空，则在展示tags的页面会多出一个空隙，所以页面展示的时候加一句话过滤掉。
