### PR TITLE
Update 2.3 Promise.md

### DIFF
--- a/book/2.3 Promise.md
+++ b/book/2.3 Promise.md
@@ -1,9 +1,9 @@
 网上已经有许多关于 Promise 的资料了，这里不在赘述。以下 4 个链接供读者学习：
 
-1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise（基础）
-2. http://liubin.org/promises-book/（开源 Promise 迷你书）
-3. http://fex.baidu.com/blog/2015/07/we-have-a-problem-with-promises/（进阶）
-4. https://promisesaplus.com/（官方定义规范）
+1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise （基础）
+2. http://liubin.org/promises-book/ （开源 Promise 迷你书）
+3. http://fex.baidu.com/blog/2015/07/we-have-a-problem-with-promises/ （进阶）
+4. https://promisesaplus.com/ （官方定义规范）
 
 Promise 用于异步流程控制，生成器与 yield 也能实现流程控制（基于 co），但不在本教程讲解范围内，读者可参考我的另一部教程 [N-club](https://github.com/nswbmw/N-club)。async/await 结合 Promise 也可以实现流程控制，有兴趣请查阅 [《ECMAScript6入门》](http://es6.ruanyifeng.com/#docs/async#async函数)。
 


### PR DESCRIPTION
直接点击上面关于promises的四个链接跳转页面会因后面括号中的说明文字而错误，不方便查看