### PR TITLE
add 'avatar-link' class to fix avatar fail to popup issue in posts page

### DIFF
--- a/book/4.9 文章.md
+++ b/book/4.9 文章.md
@@ -229,7 +229,7 @@ module.exports = {
 <div class="post-content">
   <div class="ui grid">
     <div class="four wide column">
-      <a class="avatar"
+      <a class="avatar avatar-link"
          href="/posts?author=<%= post.author._id %>"
          data-title="<%= post.author.name %> | <%= ({m: '男', f: '女', x: '保密'})[post.author.gender] %>"
          data-content="<%= post.author.bio %>">

--- a/views/components/post-content.ejs
+++ b/views/components/post-content.ejs
@@ -1,7 +1,7 @@
 <div class="post-content">
   <div class="ui grid">
     <div class="four wide column">
-      <a class="avatar"
+      <a class="avatar avatar-link"
          href="/posts?author=<%= post.author._id %>"
          data-title="<%= post.author.name %> | <%= ({m: '男', f: '女', x: '保密'})[post.author.gender] %>"
          data-content="<%= post.author.bio %>">


### PR DESCRIPTION
Originally, nothing will be popup when mouse-over the avatar on posts page.
Add 'avatar-link' class to fix avatar fail to popup issue in posts page